### PR TITLE
Move Debugbar configuration to the boot method

### DIFF
--- a/src/GitInfoServiceProvider.php
+++ b/src/GitInfoServiceProvider.php
@@ -8,11 +8,11 @@ use Illuminate\Support\ServiceProvider;
 class GitInfoServiceProvider extends ServiceProvider
 {
     /**
-     * Register any application services.
+     * Bootstrap any application services.
      *
      * @return void
      */
-    public function register()
+    public function boot()
     {
         $debugbar = App::make('debugbar');
         $debugbar->addCollector(new GitInfoCollector());


### PR DESCRIPTION
**What changed?**
Moved Debugbar configuration to the boot method. Because configuration of services must be done after all the service providers are registered.
https://laravel.com/docs/7.x/providers#the-boot-method


**How can it be tested?**
Behavior of the package should not change.
